### PR TITLE
Cache update hotfix

### DIFF
--- a/dist/comment-pr/index.js
+++ b/dist/comment-pr/index.js
@@ -9676,7 +9676,8 @@ async function run() {
         throw new Error('Failed. GITHUB_TOKEN is not set.');
     }
     const octokit = github.getOctokit(githubToken);
-    const stage = core.getInput('stage') ?? 'stg';
+    const stage = process.env.STAGE ?? 'stg';
+    console.log(stage);
     const prNumber = github.context.payload.pull_request?.number;
     if (!prNumber) {
         core.error('ERROR! PR number is undefined');

--- a/dist/comment-pr/index.js
+++ b/dist/comment-pr/index.js
@@ -9676,6 +9676,7 @@ async function run() {
         throw new Error('Failed. GITHUB_TOKEN is not set.');
     }
     const octokit = github.getOctokit(githubToken);
+    const stage = core.getInput('stage') ?? 'stg';
     const prNumber = github.context.payload.pull_request?.number;
     if (!prNumber) {
         core.error('ERROR! PR number is undefined');
@@ -9684,7 +9685,7 @@ async function run() {
     try {
         const outputsFile = (await readFileAsync('cdk-infra/outputs.json')).toString();
         const outputs = JSON.parse(outputsFile);
-        const webhook = Object.values(outputs[`auto-builder-stack-enhancedApp-stg-${process.env.GITHUB_HEAD_REF}-webhooks`])[0];
+        const webhook = Object.values(outputs[`auto-builder-stack-enhancedApp-${stage}-${process.env.GITHUB_HEAD_REF}-webhooks`])[0];
         await octokit.rest.issues.createComment({
             issue_number: prNumber,
             body: `Your feature branch infrastructure has been deployed! \n\n Your webhook URL is: ${webhook}webhook/githubEndpoint/trigger/build\n\n For more information on how to use this endpoint, follow these [instructions](https://wiki.corp.mongodb.com/x/7FzoDg).`,

--- a/dist/comment-pr/index.js
+++ b/dist/comment-pr/index.js
@@ -9677,7 +9677,6 @@ async function run() {
     }
     const octokit = github.getOctokit(githubToken);
     const stage = process.env.STAGE ?? 'stg';
-    console.log(stage);
     const prNumber = github.context.payload.pull_request?.number;
     if (!prNumber) {
         core.error('ERROR! PR number is undefined');

--- a/src/comment-pr/run.ts
+++ b/src/comment-pr/run.ts
@@ -16,7 +16,7 @@ export async function run(): Promise<void> {
 
   const octokit = github.getOctokit(githubToken);
 
-  const stage = core.getInput('stage') ?? 'stg';
+  const stage = process.env.STAGE ?? 'stg';
   const prNumber = github.context.payload.pull_request?.number;
 
   if (!prNumber) {

--- a/src/comment-pr/run.ts
+++ b/src/comment-pr/run.ts
@@ -17,7 +17,6 @@ export async function run(): Promise<void> {
   const octokit = github.getOctokit(githubToken);
 
   const stage = process.env.STAGE ?? 'stg';
-  console.log(stage);
   const prNumber = github.context.payload.pull_request?.number;
 
   if (!prNumber) {

--- a/src/comment-pr/run.ts
+++ b/src/comment-pr/run.ts
@@ -17,6 +17,7 @@ export async function run(): Promise<void> {
   const octokit = github.getOctokit(githubToken);
 
   const stage = process.env.STAGE ?? 'stg';
+  console.log(stage);
   const prNumber = github.context.payload.pull_request?.number;
 
   if (!prNumber) {

--- a/src/comment-pr/run.ts
+++ b/src/comment-pr/run.ts
@@ -16,6 +16,7 @@ export async function run(): Promise<void> {
 
   const octokit = github.getOctokit(githubToken);
 
+  const stage = core.getInput('stage') ?? 'stg';
   const prNumber = github.context.payload.pull_request?.number;
 
   if (!prNumber) {
@@ -30,7 +31,7 @@ export async function run(): Promise<void> {
 
     const webhook = Object.values(
       outputs[
-        `auto-builder-stack-enhancedApp-stg-${process.env.GITHUB_HEAD_REF}-webhooks`
+        `auto-builder-stack-enhancedApp-${stage}-${process.env.GITHUB_HEAD_REF}-webhooks`
       ],
     )[0];
 

--- a/src/rebuild-parse-cache/index.ts
+++ b/src/rebuild-parse-cache/index.ts
@@ -41,7 +41,7 @@ async function main(): Promise<void> {
   console.log(`PREVIOUS RELEASE PARSER VERSION: ${previousParserVersion}`);
 
   if (
-    currentParserVersion === previousParserVersion ||
+    currentParserVersion === previousParserVersion &&
     process.env.FORCE_RUN !== 'true'
   )
     return;

--- a/src/rebuild-parse-cache/index.ts
+++ b/src/rebuild-parse-cache/index.ts
@@ -39,12 +39,12 @@ async function main(): Promise<void> {
   // keeping this logging here to verify we are parsing the correct versions.
   console.log(`CURRENT RELEASE PARSER VERSION: ${currentParserVersion}`);
   console.log(`PREVIOUS RELEASE PARSER VERSION: ${previousParserVersion}`);
+  const shouldForceRun = process.env.FORCE_RUN === 'true';
+  if (currentParserVersion === previousParserVersion && !shouldForceRun) return;
 
-  if (
-    currentParserVersion === previousParserVersion &&
-    process.env.FORCE_RUN !== 'true'
-  )
-    return;
+  console.log(
+    `Updating cache ${shouldForceRun ? 'via force run' : 'via version update'}`,
+  );
 
   await Promise.all([
     exec.exec('npm', ['ci'], { cwd: `${WORKSPACE}` }),

--- a/src/rebuild-parse-cache/index.ts
+++ b/src/rebuild-parse-cache/index.ts
@@ -40,7 +40,11 @@ async function main(): Promise<void> {
   console.log(`CURRENT RELEASE PARSER VERSION: ${currentParserVersion}`);
   console.log(`PREVIOUS RELEASE PARSER VERSION: ${previousParserVersion}`);
 
-  if (currentParserVersion === previousParserVersion) return;
+  if (
+    currentParserVersion === previousParserVersion ||
+    process.env.FORCE_RUN !== 'true'
+  )
+    return;
 
   await Promise.all([
     exec.exec('npm', ['ci'], { cwd: `${WORKSPACE}` }),


### PR DESCRIPTION
Allow the cache updater to be run manually. Also, this PR brings in another hotfix related to using the feature branches in preprod for the github commenter bot.